### PR TITLE
Add health check endpoint to verify API status

### DIFF
--- a/src/routes/app.ts
+++ b/src/routes/app.ts
@@ -15,4 +15,13 @@ r.get("/", (_req, res) => {
   });
 });
 
+r.get("/health", (_req, res) => {
+  res.status(200).json({
+    status: "OK",
+    message: "JIMOV API is running fine 🚀",
+    uptime: process.uptime(),
+    timestamp: new Date().toISOString(),
+  });
+});
+
 export default r;


### PR DESCRIPTION
A simple API endpoint used to confirm server is running properly.
It shows the server is up and running and helps trigger alerts when API goes down.